### PR TITLE
fix: resolve #43 — save button feedback

### DIFF
--- a/web/src/components/game-player/game-player.tsx
+++ b/web/src/components/game-player/game-player.tsx
@@ -70,6 +70,8 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
   const [stats, setStats] = useState<StatDisplay[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
+  const saveStatusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Preferences
   const [fontSize, setFontSize] = useState<number>(() => {
@@ -310,10 +312,21 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
   }, [user, game.id]);
 
   const handleSave = useCallback(() => {
-    saveToLocalStorage();
-    if (user) {
-      void saveToSupabase();
+    if (saveStatusTimerRef.current) {
+      clearTimeout(saveStatusTimerRef.current);
     }
+    try {
+      saveToLocalStorage();
+      if (user) {
+        void saveToSupabase();
+      }
+      setSaveStatus("saved");
+    } catch {
+      setSaveStatus("error");
+    }
+    saveStatusTimerRef.current = setTimeout(() => {
+      setSaveStatus("idle");
+    }, 2000);
   }, [saveToLocalStorage, saveToSupabase, user]);
 
   const handleLoad = useCallback(async () => {
@@ -452,6 +465,7 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
         onSave={handleSave}
         onLoad={handleLoad}
         onStats={handleStats}
+        saveStatus={saveStatus}
       />
 
       <main className="w-full max-w-[700px] mx-auto px-4 py-6 pb-24">

--- a/web/src/components/game-player/toolbar.tsx
+++ b/web/src/components/game-player/toolbar.tsx
@@ -5,6 +5,7 @@ import {
   MinusIcon,
   PlusIcon,
   SaveIcon,
+  CheckIcon,
   FolderOpenIcon,
   BarChart3Icon,
   SunIcon,
@@ -18,6 +19,7 @@ interface ToolbarProps {
   onSave: () => void;
   onLoad: () => void;
   onStats: () => void;
+  saveStatus?: "idle" | "saved" | "error";
 }
 
 const MIN_FONT_SIZE = 16;
@@ -29,6 +31,7 @@ export function Toolbar({
   onSave,
   onLoad,
   onStats,
+  saveStatus = "idle",
 }: ToolbarProps) {
   const { theme, toggleTheme } = useTheme();
 
@@ -73,15 +76,28 @@ export function Toolbar({
           >
             <BarChart3Icon className="size-4" />
           </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onSave}
-            className="size-10 md:size-8"
-            aria-label="Save game"
-          >
-            <SaveIcon className="size-4" />
-          </Button>
+          <div className="relative">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onSave}
+              className={`size-10 md:size-8 transition-colors ${saveStatus === "saved" ? "text-green-500" : saveStatus === "error" ? "text-destructive" : ""}`}
+              aria-label="Save game"
+            >
+              {saveStatus === "saved" ? (
+                <CheckIcon className="size-4" />
+              ) : (
+                <SaveIcon className="size-4" />
+              )}
+            </Button>
+            {saveStatus !== "idle" && (
+              <span
+                className={`absolute -bottom-5 left-1/2 -translate-x-1/2 whitespace-nowrap text-[10px] font-sans leading-none ${saveStatus === "saved" ? "text-green-500" : "text-destructive"}`}
+              >
+                {saveStatus === "saved" ? "Saved!" : "Failed"}
+              </span>
+            )}
+          </div>
           <Button
             variant="ghost"
             size="icon"


### PR DESCRIPTION
## Summary
- Save button turns green with checkmark icon on success, red on failure
- Brief text label ("Saved!" / "Failed") appears for 2 seconds
- Save properly persists game state to localStorage with error handling

Closes #43

## Test plan
- [ ] Click Save — button turns green with checkmark and "Saved!" label
- [ ] Feedback auto-clears after ~2 seconds
- [ ] Game state persisted in localStorage
- [ ] Simulate failure — red button with "Failed" label