### PR TITLE
fix: resolve #44 — stats panel loading and name display

### DIFF
--- a/web/src/components/game-player/game-player.tsx
+++ b/web/src/components/game-player/game-player.tsx
@@ -68,6 +68,7 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
   const [paywallActive, setPaywallActive] = useState(false);
   const [statsOpen, setStatsOpen] = useState(false);
   const [stats, setStats] = useState<StatDisplay[]>([]);
+  const [statsLoading, setStatsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
 
@@ -347,14 +348,18 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
     const engine = engineRef.current;
     if (!engine) return;
 
-    // Ensure choicescript_stats scene is loaded
+    // Open the panel immediately so the user sees it right away
+    setStatsOpen(true);
+
+    // If the stats scene isn't loaded yet, fetch it and then populate
     if (!loadedScenesRef.current.has("choicescript_stats")) {
+      setStatsLoading(true);
       await loadSceneIntoEngine("choicescript_stats");
+      setStatsLoading(false);
     }
 
     const display = engine.getStatsDisplay();
     setStats(display);
-    setStatsOpen(true);
   }, [loadSceneIntoEngine]);
 
   // -----------------------------------------------------------------------
@@ -548,6 +553,7 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
       <StatsPanel
         stats={stats}
         open={statsOpen}
+        loading={statsLoading}
         onClose={() => setStatsOpen(false)}
       />
     </div>

--- a/web/src/components/game-player/stats-panel.tsx
+++ b/web/src/components/game-player/stats-panel.tsx
@@ -12,6 +12,7 @@ import {
 interface StatsPanelProps {
   stats: StatDisplay[];
   open: boolean;
+  loading?: boolean;
   onClose: () => void;
 }
 
@@ -74,7 +75,7 @@ function TextStat({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function StatsPanel({ stats, open, onClose }: StatsPanelProps) {
+export function StatsPanel({ stats, open, loading = false, onClose }: StatsPanelProps) {
   return (
     <Sheet open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <SheetContent side="right" className="overflow-y-auto">
@@ -88,12 +89,25 @@ export function StatsPanel({ stats, open, onClose }: StatsPanelProps) {
         </SheetHeader>
 
         <div className="space-y-5 px-4 pb-4">
-          {stats.length === 0 && (
+          {loading && (
+            <div className="space-y-5">
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="space-y-1.5">
+                  <div className="flex justify-between">
+                    <div className="h-4 w-24 rounded bg-muted animate-pulse" />
+                    <div className="h-4 w-10 rounded bg-muted animate-pulse" />
+                  </div>
+                  <div className="h-2 w-full rounded-full bg-muted animate-pulse" />
+                </div>
+              ))}
+            </div>
+          )}
+          {!loading && stats.length === 0 && (
             <p className="text-sm text-muted-foreground italic">
               No stats available yet.
             </p>
           )}
-          {stats.map((stat, index) => {
+          {!loading && stats.map((stat, index) => {
             switch (stat.type) {
               case "percent":
                 return (

--- a/web/src/lib/choicescript/engine.ts
+++ b/web/src/lib/choicescript/engine.ts
@@ -1081,7 +1081,7 @@ export class GameEngine {
     try {
       return this.resolveVariable(name.toLowerCase());
     } catch {
-      return 0;
+      return '';
     }
   }
 }


### PR DESCRIPTION
## Summary
- Panel opens instantly with loading skeleton, stats fetch in background
- Pulse-animated skeleton rows during load
- Character name no longer shows "Unknown" — fixed `safeResolveVariable` fallback from `0` to `''`

Closes #44

## Test plan
- [ ] Open stats panel — opens instantly with skeleton
- [ ] Stats populate after brief load
- [ ] Character name displays correctly
- [ ] Numeric stats still work after fallback change