### PR TITLE
fix: resolve #45 — minimal footer on /play page

### DIFF
--- a/web/src/components/layout/footer.tsx
+++ b/web/src/components/layout/footer.tsx
@@ -1,6 +1,21 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export function Footer() {
+  const pathname = usePathname();
+
+  if (pathname === "/play") {
+    return (
+      <footer className="relative z-10 border-t border-border/50 bg-background py-3 text-center">
+        <p className="text-xs text-muted-foreground">
+          &copy; {new Date().getFullYear()} The Silk Throne. All rights reserved.
+        </p>
+      </footer>
+    );
+  }
+
   return (
     <footer className="relative z-10 border-t border-border/50 bg-background">
       <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- Renders a minimal single-line copyright footer on `/play` instead of the full 630px footer
- All other pages retain the full footer unchanged
- Uses `usePathname()` to detect the `/play` route

Closes #45

## Test plan
- [ ] Visit `/play` — footer should be a single compact copyright line (~50px)
- [ ] Visit `/` or any other page — full footer should render as before
- [ ] Test on mobile viewport (375px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)