### PR TITLE
fix: resolve #46 — add chapter indicator to game player

### DIFF
--- a/web/src/components/game-player/game-player.tsx
+++ b/web/src/components/game-player/game-player.tsx
@@ -70,6 +70,7 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
   const [stats, setStats] = useState<StatDisplay[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
+  const [currentScene, setCurrentScene] = useState<string>("");
 
   // Preferences
   const [fontSize, setFontSize] = useState<number>(() => {
@@ -164,6 +165,12 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
     }
 
     setOutput(engineOutput);
+
+    // Update current scene indicator
+    const engine = engineRef.current;
+    if (engine) {
+      setCurrentScene(engine.getState().currentScene);
+    }
 
     // Scroll to top of new content after a brief delay for render
     setTimeout(() => {
@@ -453,6 +460,15 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
         onLoad={handleLoad}
         onStats={handleStats}
       />
+
+      {/* Chapter indicator */}
+      {currentScene && currentScene !== "startup" && (
+        <div className="w-full max-w-[700px] mx-auto px-4 pt-4">
+          <p className="text-xs font-sans text-[#e2b04a]/60 tracking-widest uppercase">
+            {currentScene.replace(/_/g, " ")}
+          </p>
+        </div>
+      )}
 
       <main className="w-full max-w-[700px] mx-auto px-4 py-6 pb-24">
         {/* Loading state */}


### PR DESCRIPTION
## Summary
- Adds a subtle chapter/scene indicator above the game content area
- Shows current scene name formatted from snake_case to readable text
- Uses gold accent at 60% opacity to stay non-intrusive
- Hides for the `startup` bootstrap scene

Closes #46

## Test plan
- [ ] Start a game — chapter indicator should appear after the first real scene loads
- [ ] Indicator should not show for the `startup` scene
- [ ] Text should be subtle gold, uppercase, and not break immersion
- [ ] Test on mobile viewport (375px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)