### PR TITLE
fix: #61 — [COWORK-BUG] Em-dashes rendered as double hyphens (--) throughout all game text

### DIFF
--- a/web/src/lib/choicescript/engine.ts
+++ b/web/src/lib/choicescript/engine.ts
@@ -867,6 +867,9 @@ export class GameEngine {
       return this.evaluateInlineExpression(inner.trim());
     });
 
+    // 3) Typographic em-dashes: convert -- to —
+    result = result.replace(/--/g, '\u2014');
+
     return result;
   }
 


### PR DESCRIPTION
Closes #61 — Auto-fix by Claude Code