### PR TITLE
fix: validate name input (closes #70)

### DIFF
--- a/web/src/components/game-player/game-player.tsx
+++ b/web/src/components/game-player/game-player.tsx
@@ -696,7 +696,7 @@ function InputPrompt({ variable, onSubmit }: InputPromptProps) {
       <input
         id={`input-${variable}`}
         type="text"
-        required
+        maxLength={40}
         value={value}
         onChange={(e) => {
           setValue(e.target.value);
@@ -714,7 +714,7 @@ function InputPrompt({ variable, onSubmit }: InputPromptProps) {
       />
       {showError && (
         <p className="text-sm text-red-500 font-sans">
-          Please enter a name to continue.
+          Please enter a name.
         </p>
       )}
       <Button


### PR DESCRIPTION
## Summary
- Removed `required` HTML attribute so custom validation fires (was being intercepted by browser native validation, giving no visible feedback)
- Added `maxLength={40}` to cap input length
- Existing trim + empty check logic now works correctly, showing inline error

Closes #70

## Test plan
- [ ] Leave name empty → "Please enter a name" error appears
- [ ] Enter whitespace-only → same error
- [ ] Enter 41+ chars → input capped at 40
- [ ] Enter valid name → proceeds normally