### PR TITLE
fix: remove excess empty space below game content (closes #68)

### DIFF
--- a/web/src/app/play/page.tsx
+++ b/web/src/app/play/page.tsx
@@ -78,9 +78,5 @@ async function fetchGame(): Promise<Game> {
 export default async function PlayPage() {
   const game = await fetchGame();
 
-  return (
-    <div className="flex flex-1 flex-col">
-      <PlayClient game={game} />
-    </div>
-  );
+  return <PlayClient game={game} />;
 }

--- a/web/src/app/play/play-client.tsx
+++ b/web/src/app/play/play-client.tsx
@@ -8,9 +8,5 @@ interface PlayClientProps {
 }
 
 export function PlayClient({ game }: PlayClientProps) {
-  return (
-    <div className="flex flex-1 flex-col">
-      <GamePlayer gameSlug={game.slug} game={game} />
-    </div>
-  );
+  return <GamePlayer gameSlug={game.slug} game={game} />;
 }


### PR DESCRIPTION
## Summary
- Removed unnecessary `flex flex-1 flex-col` wrapper divs from `page.tsx` and `play-client.tsx`
- Game container height now follows content naturally instead of stretching to fill viewport

Closes #68

## Test plan
- [ ] Play page has no excessive empty space below Continue button
- [ ] Content still renders correctly on mobile (375px) and desktop
- [ ] Page still fills minimum viewport height when content is short