### PR TITLE
fix: ensure toolbar stays sticky during gameplay (#108)

### DIFF
--- a/web/src/components/game-player/game-player.tsx
+++ b/web/src/components/game-player/game-player.tsx
@@ -676,7 +676,7 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
   }
 
   return (
-    <div className="bg-background">
+    <div className="bg-background pt-14">
       <Toolbar
         fontSize={fontSize}
         onFontSizeChange={handleFontSizeChange}

--- a/web/src/components/game-player/toolbar.tsx
+++ b/web/src/components/game-player/toolbar.tsx
@@ -39,7 +39,7 @@ export function Toolbar({
   const { theme, toggleTheme } = useTheme();
 
   return (
-    <div className="sticky top-16 z-30 bg-background/80 backdrop-blur-md border-b border-border/50">
+    <div className="fixed top-16 left-0 right-0 z-30 w-full bg-background/80 backdrop-blur-md border-b border-border/50">
       <div className="max-w-[700px] mx-auto flex items-center justify-between px-4 py-2">
         {/* Font size controls */}
         <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Changed toolbar from `sticky` to `fixed` positioning to avoid flex container issues
- Added `pt-14` padding to game content to offset the fixed toolbar height
- Toolbar now always visible regardless of scroll position

Fixes #108

## Test plan
- [ ] Start a game and scroll down through long text — toolbar stays visible
- [ ] Verify toolbar buttons (save, load, restart, stats, theme, font size) all remain clickable
- [ ] Test on mobile (375px) — toolbar should not overlap content
- [ ] Verify no layout shift when toolbar switches to fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)