### PR TITLE
Fix auth email redirect pointing to localhost

### DIFF
--- a/web/src/components/auth/auth-modal.tsx
+++ b/web/src/components/auth/auth-modal.tsx
@@ -86,8 +86,9 @@ export function AuthModal({ open, onOpenChange, defaultTab = "signin" }: AuthMod
         return;
       }
       const supabase = (await import("@/lib/supabase/client")).createClient();
+      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || window.location.origin;
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: `${siteUrl}/auth/callback`,
       });
       if (error) {
         setError(error.message);

--- a/web/src/context/auth-context.tsx
+++ b/web/src/context/auth-context.tsx
@@ -54,11 +54,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signUp = async (email: string, password: string) => {
     if (!isSupabaseConfigured()) return { error: "Auth not configured" };
     const supabase = createClient();
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || window.location.origin;
     const { error } = await supabase.auth.signUp({
       email,
       password,
       options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
+        emailRedirectTo: `${siteUrl}/auth/callback`,
       },
     });
     return { error: error?.message ?? null };


### PR DESCRIPTION
The email confirmation and password reset links from Supabase were redirecting to localhost because window.location.origin was used as the redirect URL. Now uses NEXT_PUBLIC_SITE_URL env var as the canonical URL, falling back to window.location.origin only if unset.

To complete the fix, two things are needed in external dashboards:

1. Set NEXT_PUBLIC_SITE_URL=https://silk-throne.vercel.app in Vercel Environment Variables (if not already set)

2. In Supabase Dashboard > Authentication > URL Configuration:
   - Set Site URL to: https://silk-throne.vercel.app
   - Add to Redirect URLs: https://silk-throne.vercel.app/auth/callback

https://claude.ai/code/session_014mocT6U2oVx3YmC8MqG5UR