### PR TITLE
Fix 7 playtest bugs: ending, errors, copy, account, legal dates

### DIFF
--- a/web/src/app/account/page.tsx
+++ b/web/src/app/account/page.tsx
@@ -28,6 +28,7 @@ export default function AccountPage() {
   const [loadingData, setLoadingData] = useState(true);
   const [deletingSave, setDeletingSave] = useState<string | null>(null);
   const [authModalOpen, setAuthModalOpen] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   // ---- fetch user data -----------------------------------------------------
   const fetchUserData = useCallback(async () => {
@@ -52,6 +53,11 @@ export default function AccountPage() {
         .order("saved_at", { ascending: false }),
     ]);
 
+    if (purchaseResult.error || saveResult.error) {
+      setFetchError("Failed to load your account data. Please try again.");
+    } else {
+      setFetchError(null);
+    }
     if (purchaseResult.data) setPurchases(purchaseResult.data);
     if (saveResult.data) setSaves(saveResult.data);
 
@@ -130,6 +136,16 @@ export default function AccountPage() {
       <h1 className="font-display text-3xl font-bold">
         Your <span className="text-gold">Account</span>
       </h1>
+
+      {/* Fetch error */}
+      {fetchError && (
+        <div className="mt-6 rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-sm text-destructive flex items-center justify-between">
+          <p>{fetchError}</p>
+          <Button variant="outline" size="sm" onClick={() => void fetchUserData()}>
+            Retry
+          </Button>
+        </div>
+      )}
 
       {/* Profile Card */}
       <Card className="mt-8">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
               },
               {
                 title: "Free Preview",
-                desc: "Play the first three chapters completely free. No account required to start — just dive in and explore.",
+                desc: "Play the first eight chapters completely free. No account required to start — just dive in and explore.",
                 icon: (
                   <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -211,7 +211,7 @@ export default function Home() {
           <div className="mt-16 grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-4">
             {[
               { step: "1", title: "Browse", desc: "Discover the world of the Khazaran Empire" },
-              { step: "2", title: "Play Free", desc: "Experience the first 3 chapters completely free" },
+              { step: "2", title: "Play Free", desc: "Experience the first eight chapters completely free" },
               { step: "3", title: "Unlock", desc: "Purchase to continue your epic journey" },
               { step: "4", title: "Continue", desc: "Your saves sync across devices — never lose progress" },
             ].map((item) => (

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -11,7 +11,7 @@ export default function PrivacyPage() {
         Privacy <span className="text-gold">Policy</span>
       </h1>
       <p className="mt-2 text-sm text-muted-foreground">
-        Last updated: January 1, 2025
+        Last updated: April 10, 2026
       </p>
 
       <div className="mt-10 space-y-8 text-sm leading-relaxed text-muted-foreground">

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -11,7 +11,7 @@ export default function TermsPage() {
         Terms of <span className="text-gold">Service</span>
       </h1>
       <p className="mt-2 text-sm text-muted-foreground">
-        Last updated: January 1, 2025
+        Last updated: April 10, 2026
       </p>
 
       <div className="mt-10 space-y-8 text-sm leading-relaxed text-muted-foreground">

--- a/web/src/components/game-player/game-player.tsx
+++ b/web/src/components/game-player/game-player.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { GameEngine } from "@/lib/choicescript/engine";
 import type { GameOutput, GameState, StatDisplay } from "@/lib/choicescript/engine";
 import { parseScene } from "@/lib/choicescript/parser";
@@ -157,7 +158,8 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
         }
 
         if (!response.ok) {
-          throw new Error(`Failed to load scene: ${sceneName} (${response.status})`);
+          console.error(`[scene] Failed to load ${sceneName}: HTTP ${response.status}`);
+          throw new Error("Failed to load the next part of the story. Please check your connection and try again.");
         }
 
         // The API returns plain text (text/plain), not JSON
@@ -298,6 +300,9 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
         } else {
           processOutput(result);
         }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "An unexpected error occurred.";
+        setError(`Something went wrong: ${msg}. Try using Undo or Restart.`);
       } finally {
         setProcessing(false);
       }
@@ -347,6 +352,9 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
       } else {
         processOutput(result);
       }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "An unexpected error occurred.";
+      setError(`Something went wrong: ${msg}. Try using Undo or Restart.`);
     } finally {
       setProcessing(false);
     }
@@ -849,13 +857,20 @@ export function GamePlayer({ gameSlug, game }: GamePlayerProps) {
                   Thank you for playing{" "}
                   <span className="text-foreground">{game.title}</span>.
                 </p>
-                <Button
-                  variant="outline"
-                  onClick={() => window.location.reload()}
-                  className="mt-4"
-                >
-                  Play Again
-                </Button>
+                <div className="flex flex-col items-center gap-3 mt-6">
+                  <Button
+                    onClick={() => setRestartDialogOpen(true)}
+                    className="bg-gold text-background hover:bg-gold/90"
+                  >
+                    Start New Game
+                  </Button>
+                  <Button
+                    render={<Link href="/" />}
+                    variant="outline"
+                  >
+                    Return to Home
+                  </Button>
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
- #147: Replace broken "Play Again" (reloaded auto-save) with "Start New Game" (uses restart dialog) + "Return to Home" link
- #148: Wrap engine.submitChoice/submitPageBreak in try/catch — show user-friendly error with Undo/Restart suggestion instead of freezing
- #149: Scene load errors show "Failed to load the next part of the story" instead of raw "Failed to load scene: scene9 (500)"
- #150: Home page copy updated from "first 3 chapters" to "first eight chapters" to match actual free_scene_list (8 free scenes)
- #152: Account page checks purchaseResult.error/saveResult.error and shows retry button instead of silently showing empty state
- #153: Terms and Privacy pages updated from Jan 2025 to Apr 2026
- #154: Ending screen now has "Start New Game" + "Return to Home"

Closes #147 #148 #149 #150 #152 #153 #154

https://claude.ai/code/session_014mocT6U2oVx3YmC8MqG5UR